### PR TITLE
Add missing format to doctype declaration

### DIFF
--- a/lib/views/ping.slim
+++ b/lib/views/ping.slim
@@ -1,4 +1,4 @@
-doctype
+doctype html
 html
   head
     meta charset="utf-8"


### PR DESCRIPTION
Project is using the old (v0.16.0) celluloid API, so you need to have this in your Gemfile:

gem 'celluloid', '0.16.0'
